### PR TITLE
update acceptance test generator

### DIFF
--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
@@ -7,11 +7,11 @@ module 'Acceptance: <%= classifiedModuleName %>',
   setup: ->
     application = startApp()
     ###
-    return null as Ember.Application.then is deprecated.
+    don't return as Ember.Application.then is deprecated.
     Newer version of QUnit uses the return value's .then
     function to wait for promises if it exists.
     ###
-    null
+    return
 
   teardown: ->
     Ember.run application, 'destroy'

--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
@@ -7,7 +7,7 @@ module 'Acceptance: <%= classifiedModuleName %>',
   setup: ->
     application = startApp()
     ###
-    don't return as Ember.Application.then is deprecated.
+    Don't return as Ember.Application.then is deprecated.
     Newer version of QUnit uses the return value's .then
     function to wait for promises if it exists.
     ###

--- a/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
+++ b/blueprints/acceptance-test/files/tests/acceptance/__name__-test.coffee
@@ -6,6 +6,12 @@ application = null
 module 'Acceptance: <%= classifiedModuleName %>',
   setup: ->
     application = startApp()
+    ###
+    return null as Ember.Application.then is deprecated.
+    Newer version of QUnit uses the return value's .then
+    function to wait for promises if it exists.
+    ###
+    null
 
   teardown: ->
     Ember.run application, 'destroy'


### PR DESCRIPTION
Newer versions of QUnit use the return value of `setup` and `teardown` to wait for promises if the return value has a `.then` function. There are a few problems with this:

1) Ember.Application.then is deprecated
2) The promise never resolves if you are calling `visit`/etc in the test block. The code to make the promise resolved can't run before setup is done (`test` waits for `setup`).

This fixes `ember generate acceptance-test` hanging by default.
